### PR TITLE
maybe fix signature for de-sugared async example

### DIFF
--- a/index.md
+++ b/index.md
@@ -435,7 +435,7 @@ name: async-io1
 This is actually sugar for...
 
 ```rust
-fn handle() -> impl Future<Output = Response> {
+fn handle(r: Request) -> impl Future<Output = Response> {
     async move {
         ... do_stuff().await ...
     }


### PR DESCRIPTION
Gut feel says the argument of the method doesn't vanish when de-sugaring the initial `async` example. I might be off track here, though. :shrug: